### PR TITLE
fix:colors-not-showing

### DIFF
--- a/assets/dash.css
+++ b/assets/dash.css
@@ -1260,10 +1260,10 @@ header .lang .dropdown .wpml-ls a {
 .block-brand .color-four{
   background: #111921;
 }
-.block-brand .colo-five{
+.block-brand .color-five{
   background: #787878;
 }
-.block-brand .colo-six{
+.block-brand .color-six{
   background: #fff;
 }
 .block-newsletter .form strong {

--- a/assets/dash.css
+++ b/assets/dash.css
@@ -1248,7 +1248,24 @@ header .lang .dropdown .wpml-ls a {
     max-width: 100%; }
     .block-brand .logo path, .block-brand .logo polygon {
       fill: #454545; }
-
+.block-brand .color-one{
+  background: #008de4;
+}
+.block-brand .color-two{
+  background: #012060;
+}
+.block-brand .color-three{
+  background: #0b0f3b;
+}
+.block-brand .color-four{
+  background: #111921;
+}
+.block-brand .colo-five{
+  background: #787878;
+}
+.block-brand .colo-six{
+  background: #fff;
+}
 .block-newsletter .form strong {
   display: none; }
 

--- a/page-brandguidelines.php
+++ b/page-brandguidelines.php
@@ -151,7 +151,7 @@ get_header(); ?>
 										?>
 										<div class="col-md-3 col-lg-2">
 											<div class="palette-item">
-												<div class="thumb" style="background:<?php the_sub_field('hexcolor'); ?>; border-radius: 8px; height: 75px;"></div>
+												<div class="thumb <?php the_sub_field('hexcolor'); ?>" style="border-radius: 8px; height: 75px;"></div>
 												<div class="text">
 													<h6 class="mb-3"><?php the_sub_field('color_title'); ?></h6>
 													<p class="text"> <?php the_sub_field('hexcolor'); ?> </p>


### PR DESCRIPTION
I think the issue was because Simply Static started adding an additional line in inline-style, so for example it should be <div class="something" style="background:#fff" > when we look on dash.org it outputs <div class="something" style="background:/#fff" > so this "/" sign is an issue. I decided to make it through the CSS styling in this way we can avoid issues with static files. 
P.S. I have tried to look into the issue with ACF, change the translation setting(that could be a reason after a new version of WP), and also updated the Simply Static several times but it didn't help.