### PR TITLE
js-file-version-change

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -104,7 +104,7 @@ function theme_scripts()
         wp_register_script('trustpilot','https://widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js',[],false,true);
         wp_enqueue_script('trustpilot'); 
         
-        wp_register_script('dash', get_template_directory_uri() . '/assets/dash.js',[],'1.62',true);
+        wp_register_script('dash', get_template_directory_uri() . '/assets/dash.js',[],'1.63',true);
         wp_enqueue_script('dash');
         wp_register_script('vue-buyspend', get_template_directory_uri() . '/assets/vue-buyspend.js',[],'1.21',true);
         wp_enqueue_script('vue-buyspend');


### PR DESCRIPTION
in hurry I forgot to chnge the js version number file in functions.

without this number it won't change anything on the website
wp_register_script('dash', get_template_directory_uri() . '/assets/dash.js',[],'1.63',true); it's basically this numbers
It's not on staging, staging don't need it since it's not connected to the git and not using Simply Static plugin

it's simply registration of the file, and for each change you have to change the version number or it won't apply anything
prev PR I did it for the css, and forgot about js